### PR TITLE
Export with git archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,10 @@ These are the possible role variables - you only need to have a small set define
     symfony2_project_console_opts: ''
     symfony2_project_composer_opts: '--no-dev --optimize-autoloader --no-interaction'
     symfony2_project_keep_releases: 5
-    symfony2_project_clean_versioning: true
     symfony2_project_relative_root: / # the path of the symfony app, relative to the git clone root
     symfony2_fire_schema_update: false # Runs doctrine:mongodb:schema:update
-    symfony2_fire_migrations: false # Runs doctrine migrations script 
+    symfony2_fire_migrations: false # Runs doctrine migrations script
+    symfony2_ssh_accept_hostkey: false # Accept unknown key, avoid blocking "yes/no" query by ssh
 ```
 
 ### Role variable defaults
@@ -97,11 +97,12 @@ As you can see, the release number default is the current date/time with seconds
     symfony2_project_branch: master
     symfony2_project_php_path: /usr/bin/php
     symfony2_project_keep_releases: 5
-    symfony2_project_clean_versioning: true
     symfony2_project_console_opts: ''
     symfony2_project_composer_opts: '--no-dev --optimize-autoloader --no-interaction'
     symfony2_fire_schema_update: false
     symfony2_fire_migrations: false
+    symfony2_project_relative_root: ~
+    symfony2_ssh_accept_hostkey: false
 ```
 
 ## Dependencies

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ These are the possible role variables - you only need to have a small set define
     symfony2_fire_schema_update: false # Runs doctrine:mongodb:schema:update
     symfony2_fire_migrations: false # Runs doctrine migrations script
     symfony2_ssh_accept_hostkey: false # Accept unknown key, avoid blocking "yes/no" query by ssh
+    symfony2_vcs_export_method: git_clone # Can be either "git_clone" or "git_archive"
 ```
 
 ### Role variable defaults

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ These are the possible role variables - you only need to have a small set define
     symfony2_project_composer_opts: '--no-dev --optimize-autoloader --no-interaction'
     symfony2_project_keep_releases: 5
     symfony2_project_clean_versioning: true
+    symfony2_project_relative_root: / # the path of the symfony app, relative to the git clone root
     symfony2_fire_schema_update: false # Runs doctrine:mongodb:schema:update
     symfony2_fire_migrations: false # Runs doctrine migrations script 
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,3 +10,4 @@ symfony2_project_console_opts: ''
 symfony2_project_composer_opts: '--no-dev --optimize-autoloader --no-interaction'
 symfony2_fire_schema_update: false
 symfony2_fire_migrations: false
+symfony2_project_relative_root: /

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,9 +5,11 @@ symfony2_project_release: ~
 symfony2_project_branch: master
 symfony2_project_php_path: php
 symfony2_project_keep_releases: 5
+symfony2_project_clean_versioning: true
 symfony2_project_console_opts: ''
 symfony2_project_composer_opts: '--no-dev --optimize-autoloader --no-interaction'
 symfony2_fire_schema_update: false
 symfony2_fire_migrations: false
 symfony2_project_relative_root: ~
+symfony2_vcs_export_method: git_clone
 symfony2_ssh_accept_hostkey: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,9 +5,9 @@ symfony2_project_release: ~
 symfony2_project_branch: master
 symfony2_project_php_path: php
 symfony2_project_keep_releases: 5
-symfony2_project_clean_versioning: true
 symfony2_project_console_opts: ''
 symfony2_project_composer_opts: '--no-dev --optimize-autoloader --no-interaction'
 symfony2_fire_schema_update: false
 symfony2_fire_migrations: false
-symfony2_project_relative_root: /
+symfony2_project_relative_root: ~
+symfony2_ssh_accept_hostkey: false

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,2 +1,3 @@
 ---
-# handlers file for symfony2
+- name: cleanup temporary files
+  file: name={{ tmp_git_ssh.stdout }} state=absent

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,3 @@
 ---
-- name: cleanup temporary files
+- name: Cleanup temporary files.
   file: name={{ tmp_git_ssh.stdout }} state=absent

--- a/tasks/generate_git_ssh_wrapper.yml
+++ b/tasks/generate_git_ssh_wrapper.yml
@@ -1,11 +1,11 @@
 ---
-- name: Create temporary GIT_SSH wrapper
+- name: Create temporary GIT_SSH wrapper.
   command: mktemp /tmp/ansible_git_ssh.XXXXXXXXX
   register: tmp_git_ssh
-  notify: cleanup temporary files
+  notify: Cleanup temporary files.
 
-- name: Make GIT_SSH wrapper executable
+- name: Make GIT_SSH wrapper executable.
   file: name={{ tmp_git_ssh.stdout }} mode="u+x"
 
-- name: Generate GIT_SSH wrapper script
+- name: Generate GIT_SSH wrapper script.
   shell: "echo 'ssh -o StrictHostKeyChecking=no $*' > {{tmp_git_ssh.stdout}}"

--- a/tasks/generate_git_ssh_wrapper.yml
+++ b/tasks/generate_git_ssh_wrapper.yml
@@ -1,0 +1,11 @@
+---
+- name: Create temporary GIT_SSH wrapper
+  command: mktemp /tmp/ansible_git_ssh.XXXXXXXXX
+  register: tmp_git_ssh
+  notify: cleanup temporary files
+
+- name: Make GIT_SSH wrapper executable
+  file: name={{ tmp_git_ssh.stdout }} mode="u+x"
+
+- name: Generate GIT_SSH wrapper script
+  shell: "echo 'ssh -o StrictHostKeyChecking=no $*' > {{tmp_git_ssh.stdout}}"

--- a/tasks/generate_git_ssh_wrapper.yml
+++ b/tasks/generate_git_ssh_wrapper.yml
@@ -7,5 +7,10 @@
 - name: Make GIT_SSH wrapper executable.
   file: name={{ tmp_git_ssh.stdout }} mode="u+x"
 
+- name: Generate GIT_SSH wrapper script to disable StrictHostKeyChecking.
+  shell: "echo 'ssh -o BatchMode=yes -o StrictHostKeyChecking=no $*' > {{tmp_git_ssh.stdout}}"
+  when: symfony2_ssh_accept_hostkey
+
 - name: Generate GIT_SSH wrapper script.
-  shell: "echo 'ssh -o StrictHostKeyChecking=no $*' > {{tmp_git_ssh.stdout}}"
+  shell: "echo 'ssh -o BatchMode=yes $*' > {{tmp_git_ssh.stdout}}"
+  when: not symfony2_ssh_accept_hostkey

--- a/tasks/git_archive_export.yml
+++ b/tasks/git_archive_export.yml
@@ -14,3 +14,11 @@
 - name: Generate GIT_SSH wrapper script.
   shell: "echo 'ssh -o BatchMode=yes $*' > {{tmp_git_ssh.stdout}}"
   when: not symfony2_ssh_accept_hostkey
+
+# GIT_SSH_COMMAND alleviates need for wrapper, but unfortunately only available in git >2.3.x
+- name: Pull sources from the repository using git archive.
+  shell: "
+    GIT_SSH={{ tmp_git_ssh.stdout }}
+    git archive --remote={{symfony2_project_repo}} {{symfony2_project_branch}}
+    | tar -x -C {{symfony2_project_root}}/releases/{{symfony2_project_release}}
+    "

--- a/tasks/git_clone_export.yml
+++ b/tasks/git_clone_export.yml
@@ -1,0 +1,7 @@
+---
+- name: Pull sources from the repository using git clone.
+  git: repo={{symfony2_project_repo}} dest={{symfony2_project_root}}/releases/{{symfony2_project_release}} version={{symfony2_project_branch}} accept_hostkey={{symfony2_ssh_accept_hostkey}} depth=1
+
+- name: Clean out versioning.
+  file: state=absent path={{symfony2_project_root}}/releases/{{symfony2_project_release}}/.git
+  when: symfony2_project_clean_versioning == true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,9 +12,13 @@
     - { path: "{{symfony2_project_root}}/shared/app/logs" }
     - { path: "{{symfony2_project_root}}/shared/web/uploads" }
 
+# GIT_SSH_COMMAND alleviates need for wrapper, but unfortunately only available in git >2.3.x
+- include: generate_git_ssh_wrapper.yml
+  when: symfony2_ssh_accept_hostkey
 
 - name: Pull sources from the repository.
   shell: "
+    {{ ('GIT_SSH=' + tmp_git_ssh.stdout) if tmp_git_ssh.stdout is defined else '' }}
     git archive --remote={{symfony2_project_repo}} {{symfony2_project_branch}}
     | tar -x -C {{symfony2_project_root}}/releases/{{symfony2_project_release}}
     "

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,12 +12,12 @@
     - { path: "{{symfony2_project_root}}/shared/app/logs" }
     - { path: "{{symfony2_project_root}}/shared/web/uploads" }
 
-- name: Pull sources from the repository.
-  git: repo={{symfony2_project_repo}} dest={{symfony2_project_root}}/releases/{{symfony2_project_release}} version={{symfony2_project_branch}} accept_hostkey=yes
 
-- name: Clean out versioning.
-  file: state=absent path={{symfony2_project_root}}/releases/{{symfony2_project_release}}/.git
-  when: symfony2_project_clean_versioning == true
+- name: Pull sources from the repository.
+  shell: "
+    git archive --remote={{symfony2_project_repo}} {{symfony2_project_branch}}
+    | tar -x -C {{symfony2_project_root}}/releases/{{symfony2_project_release}}
+    "
 
 # will be replaced with symlink
 - name: Ensure logs directory is not present.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,20 +21,20 @@
 
 # will be replaced with symlink
 - name: Ensure logs directory is not present.
-  file: state=absent path={{symfony2_project_root}}/releases/{{symfony2_project_release}}/app/logs
+  file: state=absent path={{symfony2_project_root}}/releases/{{symfony2_project_release}}/{{symfony2_project_relative_root}}/app/logs
 
 - name: Create symlinks to shared directories.
   file: state=link src={{item.src}} path={{item.path}}
   with_items:
-    - { src: "{{symfony2_project_root}}/shared/app/logs", path: "{{symfony2_project_root}}/releases/{{symfony2_project_release}}/app/logs" }
-    - { src: "{{symfony2_project_root}}/shared/web/uploads", path: "{{symfony2_project_root}}/releases/{{symfony2_project_release}}/web/uploads" }
+    - { src: "{{symfony2_project_root}}/shared/app/logs", path: "{{symfony2_project_root}}/releases/{{symfony2_project_release}}/{{symfony2_project_relative_root}}/app/logs" }
+    - { src: "{{symfony2_project_root}}/shared/web/uploads", path: "{{symfony2_project_root}}/releases/{{symfony2_project_release}}/{{symfony2_project_relative_root}}/web/uploads" }
 
 - name: Check if config dir exists.
-  stat: path={{symfony2_project_root}}/releases/{{symfony2_project_release}}/app/config
+  stat: path={{symfony2_project_root}}/releases/{{symfony2_project_release}}/{{symfony2_project_relative_root}}/app/config
   register: config_dir
 
 - name: Link configs dir if not yet exists.
-  file: state=link src={{symfony2_project_root}}/shared/app/config path={{symfony2_project_root}}/releases/{{symfony2_project_release}}/app/config
+  file: state=link src={{symfony2_project_root}}/shared/app/config path={{symfony2_project_root}}/releases/{{symfony2_project_release}}/{{symfony2_project_relative_root}}/app/config
   when: config_dir.stat.exists == false
 
 - name: Check if shared/app/config/parameters.ini exists.
@@ -42,7 +42,7 @@
   register: parameters_ini
 
 - name: Create symlink for app/config/parameters.ini from shared directory.
-  shell: ln -s {{symfony2_project_root}}/shared/app/config/parameters.ini {{symfony2_project_root}}/releases/{{symfony2_project_release}}/app/config/parameters.ini creates={{symfony2_project_root}}/releases/{{symfony2_project_release}}/app/config/parameters.ini
+  shell: ln -s {{symfony2_project_root}}/shared/app/config/parameters.ini {{symfony2_project_root}}/releases/{{symfony2_project_release}}/{{symfony2_project_relative_root}}/app/config/parameters.ini creates={{symfony2_project_root}}/releases/{{symfony2_project_release}}/{{symfony2_project_relative_root}}/app/config/parameters.ini
   when: parameters_ini.stat.exists
 
 - name: Check if composer exists.
@@ -58,21 +58,21 @@
   when: composer_file.stat.exists == true
 
 - name: Run composer install.
-  shell: cd {{symfony2_project_root}}/releases/{{symfony2_project_release}} && export SYMFONY_ENV={{symfony2_project_env}} && {{symfony2_project_php_path}} {{symfony2_project_composer_path}}/composer.phar install {{symfony2_project_composer_opts}}
+  shell: cd {{symfony2_project_root}}/releases/{{symfony2_project_release}}/{{symfony2_project_relative_root}} && export SYMFONY_ENV={{symfony2_project_env}} && {{symfony2_project_php_path}} {{symfony2_project_composer_path}}/composer.phar install {{symfony2_project_composer_opts}}
 
 - name: Dump assets.
-  shell: cd {{symfony2_project_root}}/releases/{{symfony2_project_release}} && {{symfony2_project_php_path}} app/console assetic:dump --env={{symfony2_project_env}} {{symfony2_project_console_opts}}
+  shell: cd {{symfony2_project_root}}/releases/{{symfony2_project_release}}/{{symfony2_project_relative_root}} && {{symfony2_project_php_path}} app/console assetic:dump --env={{symfony2_project_env}} {{symfony2_project_console_opts}}
 
 - name: Run migrations.
-  shell: cd {{symfony2_project_root}}/releases/{{symfony2_project_release}} && if $(grep doctrine-migrations-bundle composer.json); then {{symfony2_project_php_path}} app/console doctrine:migrations:migrate -n; fi
+  shell: cd {{symfony2_project_root}}/releases/{{symfony2_project_release}}/{{symfony2_project_relative_root}} && if $(grep doctrine-migrations-bundle composer.json); then {{symfony2_project_php_path}} app/console doctrine:migrations:migrate -n; fi
   when: symfony2_fire_migrations == true
 
 - name: Run mongodb schema update.
-  shell: cd {{symfony2_project_root}}/releases/{{symfony2_project_release}} && if $(grep mongodb-odm composer.json); then {{symfony2_project_php_path}} app/console doctrine:mongodb:schema:update --no-interaction; fi
+  shell: cd {{symfony2_project_root}}/releases/{{symfony2_project_release}}/{{symfony2_project_relative_root}} && if $(grep mongodb-odm composer.json); then {{symfony2_project_php_path}} app/console doctrine:mongodb:schema:update --no-interaction; fi
   when: symfony2_fire_schema_update == true
 
 - name: Create symlink.
-  file: state=link src={{symfony2_project_root}}/releases/{{symfony2_project_release}} path={{symfony2_project_root}}/current
+  file: state=link src={{symfony2_project_root}}/releases/{{symfony2_project_release}}/{{symfony2_project_relative_root}} path={{symfony2_project_root}}/current
 
 - name: Cleanup releases.
   shell: cd {{symfony2_project_root}}/releases && ls -t1 | tail -n +$(({{symfony2_project_keep_releases}}+1)) | xargs -n1 rm -rf

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,15 +12,12 @@
     - { path: "{{symfony2_project_root}}/shared/app/logs" }
     - { path: "{{symfony2_project_root}}/shared/web/uploads" }
 
-# GIT_SSH_COMMAND alleviates need for wrapper, but unfortunately only available in git >2.3.x
-- include: generate_git_ssh_wrapper.yml
+# include does not allow templated path
+- include: "git_clone_export.yml"
+  when: symfony2_vcs_export_method == "git_clone"
 
-- name: Pull sources from the repository.
-  shell: "
-    GIT_SSH={{ tmp_git_ssh.stdout }}
-    git archive --remote={{symfony2_project_repo}} {{symfony2_project_branch}}
-    | tar -x -C {{symfony2_project_root}}/releases/{{symfony2_project_release}}
-    "
+- include: "git_archive_export.yml"
+  when: symfony2_vcs_export_method == "git_archive"
 
 # will be replaced with symlink
 - name: Ensure logs directory is not present.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,11 +14,10 @@
 
 # GIT_SSH_COMMAND alleviates need for wrapper, but unfortunately only available in git >2.3.x
 - include: generate_git_ssh_wrapper.yml
-  when: symfony2_ssh_accept_hostkey
 
 - name: Pull sources from the repository.
   shell: "
-    {{ ('GIT_SSH=' + tmp_git_ssh.stdout) if tmp_git_ssh.stdout is defined else '' }}
+    GIT_SSH={{ tmp_git_ssh.stdout }}
     git archive --remote={{symfony2_project_repo}} {{symfony2_project_branch}}
     | tar -x -C {{symfony2_project_root}}/releases/{{symfony2_project_release}}
     "

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -16,5 +16,4 @@
     symfony2_project_console_opts: '--no-debug'
     symfony2_project_composer_opts: '--no-dev --optimize-autoloader'
     symfony2_project_keep_releases: 5
-    symfony2_project_clean_versioning: true
     symfony2_fire_migrations: true


### PR DESCRIPTION
__NOTE:__ this branch relies on #23, please check that PR first.

Instead of cloning the entire repository history (should have been done with _depth=1_ anyway), we can use the [`git archive`](http://git-scm.com/docs/git-archive) command to dump only the contents of the tree at the branch/commit specified by `symfony2_project_branch`. This also effectively removes the `symfony2_project_clean_versioning` option.

In addition, we need to consider the case when `ssh` on the host has not yet saved the host key of the Git repository server - for this we need to generate a temporary wrapper script so that we can pass the `StrictHostKeyChecking` flag. 

We also use the wrapper script to _always_ set `BatchMode=yes` in order to avoid any interactive questions from ssh.
