### PR TITLE
Allow composer to be managed by other tools

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,7 @@ symfony2_project_php_path: php
 symfony2_project_keep_releases: 5
 symfony2_project_clean_versioning: true
 symfony2_project_console_opts: ''
+symfony2_project_maintain_composer: true
 symfony2_project_composer_opts: '--no-dev --optimize-autoloader --no-interaction'
 symfony2_fire_schema_update: false
 symfony2_fire_migrations: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -48,14 +48,15 @@
 - name: Check if composer exists.
   stat: path={{symfony2_project_composer_path}}/composer.phar
   register: composer_file
+  when: symfony2_project_maintain_composer == true
 
 - name: Install composer.
   get_url: url=https://getcomposer.org/composer.phar dest={{symfony2_project_composer_path}} mode=0755 validate_certs=no
-  when: composer_file.stat.exists == false
+  when: symfony2_project_maintain_composer == true and composer_file.stat.exists == false
 
 - name: Update composer if already exists.
   shell: "{{symfony2_project_composer_path}}/composer.phar selfupdate"
-  when: composer_file.stat.exists == true
+  when: symfony2_project_maintain_composer == true and composer_file.stat.exists == true
 
 - name: Run composer install.
   shell: cd {{symfony2_project_root}}/releases/{{symfony2_project_release}} && export SYMFONY_ENV={{symfony2_project_env}} && {{symfony2_project_php_path}} {{symfony2_project_composer_path}}/composer.phar install {{symfony2_project_composer_opts}}


### PR DESCRIPTION
We handle composer in other roles and it is installed / updated via
a user with higher privileges than the user the sites managed by. We
don't want the user the project is deployed as to be able to deal with
it. This is a backwards compatible change and seems to work.