### PR TITLE
Add mysql schema update option

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,3 +30,4 @@ symfony_project_enable_cache_warmup: True
 symfony_project_fire_schema_update: False
 symfony_project_fire_migrations: False
 symfony_project_symlink_assets: True
+symfony_project_database_type: mongodb

--- a/tasks/50-migrations.yml
+++ b/tasks/50-migrations.yml
@@ -5,4 +5,8 @@
 
 - name: Run mongodb schema update.
   action: shell {{symfony_project_php_path}} {{symfony_console}} doctrine:mongodb:schema:update --no-interaction
-  when: symfony_project_fire_schema_update == true and composer_content.stdout.find('mongodb-odm') != -1
+  when: symfony_project_fire_schema_update == true and composer_content.stdout.find('mongodb-odm') != -1 and symfony_project_database_type = 'mongodb'
+
+- name: Run mysql schema update.
+  action: shell {{symfony_project_php_path}} {{symfony_console}} doctrine:schema:update --force --no-interaction
+  when: symfony_project_fire_schema_update == true and symfony_project_database_type = 'mysql'


### PR DESCRIPTION
The role only supports **mongodb** schema update. With a simple change and an additional variable, it now supports **mysql** and it could easily be extended to support more database types.