### PR TITLE
ansible 2.0 set_fact change

### DIFF
--- a/tasks/00-facts.yml
+++ b/tasks/00-facts.yml
@@ -2,7 +2,8 @@
 # simplify folder and command vars
 
 - name: Check/define release name.
-  set_fact: symfony_project_release={{ lookup('pipe', 'date +%Y%m%d%H%M%S') }}
+  set_fact:
+    symfony_project_release: "{{ lookup('pipe', 'date +%Y%m%d%H%M%S') }}"
   when: symfony_project_release == None
 
 - name: Set symfony_current_release.


### PR DESCRIPTION
with ansible 2.0 caused error:

TASK [servergrove.symfony2 : Check/define release name.] ***********************
task path: /etc/ansible/roles/servergrove.symfony2/tasks/00-facts.yml:4
fatal: [xxx]: FAILED! => {"failed": true, "msg": "ERROR! template error while templating string: unexpected 'end of template'"}