### PR TITLE
Fix order of tests for managing composer

### DIFF
--- a/tasks/20-composer.yml
+++ b/tasks/20-composer.yml
@@ -10,7 +10,7 @@
 
 - name: Update composer if already exists.
   shell: "{{symfony_project_composer_path}} selfupdate"
-  when: composer_file.stat.exists == True and symfony_project_manage_composer == True
+  when: symfony_project_manage_composer == True and composer_file.stat.exists == True
 
 - name: Add github token
   shell: "{{symfony_project_composer_path}} config -g github-oauth.github.com {{symfony_project_github_token}}"


### PR DESCRIPTION
When symfony_project_manage_composer is False, there is an error  'dict object' has no attribute 'stat'. Because when it is false you don't check if it exists, so composer_file has no .stat. But it is tested first so fails with an error.

Swapping the order of the tests fixes the issue.