### PR TITLE
conditionally use assetic

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -33,6 +33,7 @@ symfony_project_enable_cache_warmup: True
 symfony_project_fire_schema_update: False
 symfony_project_fire_migrations: False
 symfony_project_symlink_assets: True
+symfony_project_assetic_dump: True
 
 # ensured to be absent in release and linked from shared
 symfony_project_shared_folders:

--- a/tasks/40-assets.yml
+++ b/tasks/40-assets.yml
@@ -1,7 +1,7 @@
 ---
 - name: Dump assetic assets.
   shell: cd {{symfony_current_release_dir}} && {{symfony_project_php_path}} {{symfony_project_php_options}} {{symfony_console}} assetic:dump {{symfony_project_console_opts}}
-  when: composer_content.stdout.find('assetic-bundle') != -1
+  when: symfony_project_assetic_dump == True and composer_content.stdout.find('assetic-bundle') != -1
 
 - name: Symlink/install assets.
   shell: cd {{symfony_current_release_dir}} && {{symfony_project_php_path}} {{symfony_project_php_options}} {{symfony_console}} assets:install --symlink {{symfony_project_console_opts}}


### PR DESCRIPTION
We have a situation where even though assetic is installed we don't want to use it on deploy. This allows it to be disabled.