### PR TITLE
support clearing the cache on sf3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ These are the possible role variables - you only need to have a small set define
     symfony_project_config_dir: 'app/config' # symfony configuration dir
     symfony_project_parameters_file: parameters.yml # optional fixed parameters file in shared
     symfony_project_cache_command: cache:warmup
+    symfony_project_cache_dir: app # sf >= 3.0 var
 
     symfony_project_manage_composer: True
     symfony_project_composer_opts: '--no-dev --optimize-autoloader --no-interaction'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,6 +24,7 @@ symfony_project_console_command: "app/console"
 symfony_project_config_dir: "app/config"
 symfony_project_parameters_file: parameters.yml
 symfony_project_cache_command: cache:warmup
+symfony_project_cache_dir: app
 
 symfony_project_manage_composer: True
 symfony_project_composer_opts: "--no-dev --optimize-autoloader --no-interaction"

--- a/tasks/30-cache.yml
+++ b/tasks/30-cache.yml
@@ -1,6 +1,6 @@
 ---
 - name: Remove cache dir manually.
-  file: state=absent path={{symfony_current_release_dir}}/app/cache/{{symfony_project_env}}
+  file: state=absent path={{symfony_current_release_dir}}/{{symfony_project_cache_dir}}/cache/{{symfony_project_env}}
   when: symfony_project_enable_cache_warmup == True
   tags:
     - cache


### PR DESCRIPTION
sf3.x uses the var/cache dir, not app/cache dir. So I introduced a variable with a default for 2.x so that you can set it to either app or var. 