### PR TITLE
Pass the php path to composer

### DIFF
--- a/tasks/20-composer.yml
+++ b/tasks/20-composer.yml
@@ -9,11 +9,11 @@
   when: symfony_project_manage_composer == True and composer_file.stat.exists == False
 
 - name: Update composer if already exists.
-  shell: "{{symfony_project_composer_path}} selfupdate"
+  shell: "{{symfony_project_php_path}} {{symfony_project_composer_path}} selfupdate"
   when: symfony_project_manage_composer == True and composer_file.stat.exists == True
 
 - name: Add github token
-  shell: "{{symfony_project_composer_path}} config -g github-oauth.github.com {{symfony_project_github_token}}"
+  shell: "{{symfony_project_php_path}} {{symfony_project_composer_path}} config -g github-oauth.github.com {{symfony_project_github_token}}"
   when: symfony_project_github_token != None
 
 - name: Link composer to project dir.


### PR DESCRIPTION
Some systems have no php binary (mine has php56, php72, php73 for example). This allows the deployment to work when the php_path is set.